### PR TITLE
PIPs: PIP11 remove template heading, add forum post link

### DIFF
--- a/PIPs/PIP-11.md
+++ b/PIPs/PIP-11.md
@@ -1,9 +1,6 @@
-
-## When you want to submit a new PIP, please follow the following format! 
-
 | PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
 |-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 11 | Deterministic finality via Milestones | Proposal to introduce Milestones in Polygon PoS to have deterministic finality | [Vaibhav Jindal](https://github.com/VAIBHAVJINDAL3012), [Arpit Temani](https://github.com/temaniarpit27), [Evgeniy Danilenko](https://github.com/JekaMas/), [Manav Darji](https://github.com/manav2401), [Sandeep Sreenath](https://github.com/ssandeep) | URL to Forum  | Draft  | Core | 2023-05-05 |
+| 11 | Deterministic finality via Milestones | Proposal to introduce Milestones in Polygon PoS to have deterministic finality | [Vaibhav Jindal](https://github.com/VAIBHAVJINDAL3012), [Arpit Temani](https://github.com/temaniarpit27), [Evgeniy Danilenko](https://github.com/JekaMas/), [Manav Darji](https://github.com/manav2401), [Sandeep Sreenath](https://github.com/ssandeep) | [Forum Post](https://forum.polygon.technology/t/pip-11-deterministic-finality-via-milestones/11918/)  | Draft  | Core | 2023-05-05 |
 ---
 
 ## Table of contents


### PR DESCRIPTION
# Description

Add forum post link and remove un-wanted heading copied from template. 

## Type of change

Please delete options that are not relevant.

- [ ]  New PIP
- [x]  Revision to an existing PIP
- [ ]  This change requires a documentation update
- [ ]  My edit follows the style guidelines
