### PR TITLE
dev: add: PIP-23 excluded EIPs

### DIFF
--- a/PIPs/PIP-23.md
+++ b/PIPs/PIP-23.md
@@ -21,8 +21,10 @@ The Shanghai PIP will enable the following upgrades:
 * [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
 * [EIP-6049: Deprecate SELFDESTRUCT](https://eips.ethereum.org/EIPS/eip-6049)
 
-Compared to Ethereum Shanghai upgrade, the following EIP will not be included in Polygon specs, for obvious reasons:
+Compared to Ethereum Shanghai upgrade, the following EIP will not be included in Polygon specs:
 * [EIP-4898: Beacon chain push withdrawals as operations](https://eips.ethereum.org/EIPS/eip-4895)
+ 
+The aforementioned EIP has been specifically excluded because Polygon PoS has no concept of beacon chain. Whilst Ethereum validators are now enabled to withdraw ETHs, in Polygon PoS chain the validators staking is done on Ethereum L1 directly, and its operations are synced with `bor` chain by using `heimdall` layer.
 
 ## Backwards Compatibility
 

--- a/PIPs/PIP-23.md
+++ b/PIPs/PIP-23.md
@@ -21,6 +21,9 @@ The Shanghai PIP will enable the following upgrades:
 * [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
 * [EIP-6049: Deprecate SELFDESTRUCT](https://eips.ethereum.org/EIPS/eip-6049)
 
+Compared to Ethereum Shanghai upgrade, the following EIP will not be included in Polygon specs, for obvious reasons:
+* [EIP-4898: Beacon chain push withdrawals as operations](https://eips.ethereum.org/EIPS/eip-4895)
+
 ## Backwards Compatibility
 
 This PIP will not be backward compatible with the current implementation of `bor` and will therefore require a hard fork.


### PR DESCRIPTION
# Description

Update PIP-23 by mentioning the excluded EIPs compared to Ethereum Shanghai upgrade.

## Type of change

Please delete options that are not relevant.

- [ ]  New PIP
- [x]  Revision to an existing PIP
- [ ]  This change requires a documentation update
- [ ]  My edit follows the style guidelines
