### PR TITLE
Enable a subset of `eipw` lints (closes #117)

### DIFF
--- a/.eipw.toml
+++ b/.eipw.toml
@@ -1,0 +1,83 @@
+[[modifiers]]
+kind = "set-default-annotation"
+name = "status"
+value = "Stagnant"
+annotation_type = "warning"
+
+[[modifiers]]
+kind = "set-default-annotation"
+name = "status"
+value = "Withdrawn"
+annotation_type = "warning"
+
+[lints.preamble-author]
+kind = "preamble-author"
+name = "author"
+
+[lints.preamble-order]
+kind = "preamble-order"
+names = [
+    "pip",
+    "title",
+    "description",
+    "author",
+    "discussion",
+    "status",
+    "type",
+    "date",
+]
+
+[lints.preamble-req]
+kind = "preamble-required"
+names = [
+    "pip",
+    "title",
+    "description",
+    "author",
+    "discussion",
+    "status",
+    "type",
+    "date",
+]
+
+[lints.preamble-date-created]
+kind = "preamble-date"
+name = "date"
+
+[lints.preamble-trim]
+kind = "preamble-trim"
+
+[lints.preamble-pip]
+kind = "preamble-uint"
+name = "pip"
+
+[lints.preamble-no-dup]
+kind = "preamble-no-duplicates"
+
+[lints.preamble-re-description-pip-dash]
+kind = "preamble-regex"
+name = "description"
+mode = "excludes"
+pattern = '(?i)pip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `PIP-N` (not `PIPN` or `PIP N`)"
+
+[lints.preamble-re-title-pip-dash]
+kind = "preamble-regex"
+name = "title"
+mode = "excludes"
+pattern = '(?i)pip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `PIP-N` (not `PIPN` or `PIP N`)"
+
+[lints.preamble-discussion]
+kind = "preamble-url"
+name = "discussion"
+
+[lints.preamble-list-author]
+kind = "preamble-list"
+name = "author"
+
+[lints.markdown-re-pip-dash]
+kind = "markdown-regex"
+mode = "excludes"
+pattern = '(?i)pip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `PIP-N` (not `PIPN` or `PIP N`)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+
+jobs:
+  eipw-validator:
+    name: PIP Validator
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
+
+      - uses: ethereum/eipw-action@88d2e579767028a48f712cd9e8d25639347dc236
+        id: eipw
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          unchecked: 1
+          path: PIPs/
+          options-file: .eipw.toml

--- a/PIPs/PIP-01.md
+++ b/PIPs/PIP-01.md
@@ -1,9 +1,15 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 1 | PIP Purpose and Guidelines  | Describes community standards for the Polygon ecosystem, including core protocol specifications | Harry Rook, Mateusz Rzeszowski | [Forum](https://forum.polygon.technology/t/pip-1-pip-purpose-and-guidelines/11356)  | Continuous | Informational | 2023-22-02
+---
+pip: 1
+title: PIP Purpose and Guidelines
+description: Describes community standards for the Polygon ecosystem, including core protocol specifications
+author: Harry Rook (@hrook1), Mateusz Rzeszowski
+discussion: https://forum.polygon.technology/t/pip-1-pip-purpose-and-guidelines/11356
+status: Continuous
+type: Informational
+date: 2023-02-22
 ---
 
-### Abstract 
+### Abstract
 
 Polygon Improvement Proposals (PIPs) describe community standards for the Polygon ecosystem, including core protocol specifications such as Heimdall and Bor, client APIs, and contract standards, etc.
 

--- a/PIPs/PIP-02.md
+++ b/PIPs/PIP-02.md
@@ -1,6 +1,12 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 2 | Proposal to distribute and decentralize staking power across the Polygon chain  | Proposal to increase the minimun commission. | Delroy Bosco | [Forum](https://forum.polygon.technology/t/pip-2-proposal-to-distribute-and-decentralize-staking-power-across-the-polygon-chain/219/11)  | Stagnant | Contracts | 2021-11-01
+---
+pip: 2
+title: Proposal to distribute and decentralize staking power across the Polygon chain
+description: Proposal to increase the minimun commission.
+author: Delroy Bosco
+discussion: https://forum.polygon.technology/t/pip-2-proposal-to-distribute-and-decentralize-staking-power-across-the-polygon-chain/219/11
+status: Stagnant
+type: Contracts
+date: 2021-11-01
 ---
 
 ### Abstract:

--- a/PIPs/PIP-03.md
+++ b/PIPs/PIP-03.md
@@ -1,7 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|---------------------------------------|
-| 3 | Auction Mechansim - A Mechanism to replace bad and under-performing validators| Proposes a mechanism to replace under-performing validators |Delroy Bosco | [Forum](https://forum.polygon.technology/t/pip-3-auction-mechansim-a-mechanism-to-replace-bad-and-under-performing-validators/8270/6)|Stagnant | Contracts | 2021-06-01 |
-
+---
+pip: 3
+title: Auction Mechansim - A Mechanism to replace bad and under-performing validator
+description: Proposes a mechanism to replace under-performing validators
+author: Delroy Bosco
+discussion: https://forum.polygon.technology/t/pip-3-auction-mechansim-a-mechanism-to-replace-bad-and-under-performing-validators/8270/6
+status: Stagnant
+type: Contracts
+date: 2021-06-01
+---
 
 ### Abstract:
 

--- a/PIPs/PIP-04.md
+++ b/PIPs/PIP-04.md
@@ -1,7 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 4 | Validator Performance Management Proposal   | Proposes a framework that will allow further decentralization of the network by means of validator self-regulation.   | Eric Hill, Harry Rook, Mateusz Rzesowski | [Forum](https://forum.polygon.technology/t/pip-4-validator-performance-management/9956) | Final | Contracts | 2022-08-22|
-
+---
+pip: 4
+title: Validator Performance Management Proposal
+description: Proposes a framework that will allow further decentralization of the network by means of validator self-regulation.
+author: Eric Hill, Harry Rook (@hrook1), Mateusz Rzesowski
+discussion: https://forum.polygon.technology/t/pip-4-validator-performance-management/9956
+status: Final
+type: Contracts
+date: 2022-08-22
+---
 
 
 ### Abstract

--- a/PIPs/PIP-05.md
+++ b/PIPs/PIP-05.md
@@ -1,8 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 5 | Change in SprintLength  | Proposes a change in the SprintLenght | Sandeep Sreenath, Paul O’Leary, Arpit Temani | [Forum](https://forum.polygon.technology/t/pip-5-change-in-sprintlength/10874/4)  | Final  | Core |      2023-01-10        |
-
-
+---
+pip: 5
+title: Change in SprintLength
+description: Proposes a change in the SprintLenght
+author: Sandeep Sreenath (@ssandeep), Paul O’Leary, Arpit Temani
+discussion: https://forum.polygon.technology/t/pip-5-change-in-sprintlength/10874/4
+status: Final
+type: Core
+date: 2023-01-10
+---
 
 ### Motivation
 

--- a/PIPs/PIP-06.md
+++ b/PIPs/PIP-06.md
@@ -1,9 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 6 | Change in BaseFeeChangeDenominator  | Proposes a change in the BaseFeeChangeDenominator | Shivam Sharma, Sandeep Sreenath, Paul O’Leary | [Forum](https://forum.polygon.technology/t/pip-6-change-in-basefeechangedenominator/10875/4)  | Final | Core | 2023-01-10 |
-
-
-
+---
+pip: 6
+title: Change in BaseFeeChangeDenominator
+description: Proposes a change in the BaseFeeChangeDenominator
+author: Shivam Sharma, Sandeep Sreenath (@ssandeep), Paul O’Leary
+discussion: https://forum.polygon.technology/t/pip-6-change-in-basefeechangedenominator/10875/4
+status: Final
+type: Core
+date: 2023-01-10
+---
 
 ### Motivation
 

--- a/PIPs/PIP-07.md
+++ b/PIPs/PIP-07.md
@@ -1,8 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 7 | Delhi Hardfork  | Proposes the Delhi Hardfork | Harry Rook | [Forum](https://forum.polygon.technology/t/pip-7-delhi-hardfork/10904/2) | Final  | Core | 2023-01-12 |
-
-
+---
+pip: 7
+title: Delhi Hardfork
+description: Proposes the Delhi Hardfork
+author: Harry Rook (@hrook1)
+discussion: https://forum.polygon.technology/t/pip-7-delhi-hardfork/10904/2
+status: Final
+type: Core
+date: 2023-01-12
+---
 
 ### Abstract
 

--- a/PIPs/PIP-08.md
+++ b/PIPs/PIP-08.md
@@ -1,7 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 8 | PIP Classification, Workflow and Implementation | Describes a proposed classification scheme for PIPs and their respective work flows. | Harry Rook , Mateusz Rzeszowski | [Forum](https://forum.polygon.technology/t/pip-8-pip-classification-workflow-and-implementation/11365/1) | Continuous | Informational | 2023-02-21 | 
-
+---
+pip: 8
+title: PIP Classification, Workflow and Implementation
+description: Describes a proposed classification scheme for PIPs and their respective work flows.
+author: Harry Rook (@hrook1), Mateusz Rzeszowski
+discussion: https://forum.polygon.technology/t/pip-8-pip-classification-workflow-and-implementation/11365/1
+status: Continuous
+type: Informational
+date: 2023-02-21
+---
 
 ## Abstract
 

--- a/PIPs/PIP-09.md
+++ b/PIPs/PIP-09.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 9 | Performance Benchmark Adjustment | Maintaining the current level of Performance Benchmark at 95% | Delroy Bosco, Jackson Lewis, Harry Rook, Mateusz Rzeszowski| [Forum](https://forum.polygon.technology/t/pip-9-performance-benchmark-adjustment/11387) | Final | Contracts | 2023-02-23 |
+---
+pip: 9
+title: Performance Benchmark Adjustment
+description: Maintaining the current level of Performance Benchmark at 95%
+author: Delroy Bosco, Jackson Lewis, Harry Rook (@hrook1), Mateusz Rzeszowsk
+discussion: https://forum.polygon.technology/t/pip-9-performance-benchmark-adjustment/11387
+status: Final
+type: Contracts
+date: 2023-02-23
+---
 
 ### Abstract
 

--- a/PIPs/PIP-10.md
+++ b/PIPs/PIP-10.md
@@ -1,6 +1,12 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 10 | Increase StateSync Confirmations  | Proposal to increase the statesync confirmations in bor | [Krishna Upadhyaya](https://github.com/0xKrishna), [Manav Darji](https://github.com/manav2401), [Pratik Patil](https://github.com/pratikspatil024) | [Forum](https://forum.polygon.technology/t/proposal-increase-statesync-confirmations/11779)  | Draft | Core | 2023-18-04
+---
+pip: 10
+title: Increase StateSync Confirmations
+description: Proposal to increase the statesync confirmations in bor
+author: Krishna Upadhyaya (@0xKrishna), Manav Darji (@manav2401), Pratik Patil (@pratikspatil024)
+discussion: https://forum.polygon.technology/t/proposal-increase-statesync-confirmations/11779
+status: Draft
+type: Core
+date: 2023-04-18
 ---
 
 ### Abstract 

--- a/PIPs/PIP-11.md
+++ b/PIPs/PIP-11.md
@@ -1,6 +1,12 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 11 | Deterministic finality via Milestones | Proposal to introduce Milestones in Polygon PoS to have deterministic finality | [Vaibhav Jindal](https://github.com/VAIBHAVJINDAL3012), [Arpit Temani](https://github.com/temaniarpit27), [Evgeniy Danilenko](https://github.com/JekaMas/), [Manav Darji](https://github.com/manav2401), [Sandeep Sreenath](https://github.com/ssandeep) | [Forum Post](https://forum.polygon.technology/t/pip-11-deterministic-finality-via-milestones/11918/)  | Last Call  | Core | 2023-09-25 |
+---
+pip: 11
+title: Deterministic finality via Milestones
+description: Proposal to introduce Milestones in Polygon PoS to have deterministic finality
+author: Vaibhav Jindal (@VAIBHAVJINDAL3012), Arpit Temani (@temaniarpit27), Evgeniy Danilenko (@JekaMas), Manav Darji (@manav2401), Sandeep Sreenath (@ssandeep)
+discussion: https://forum.polygon.technology/t/pip-11-deterministic-finality-via-milestones/11918/
+status: Last Call
+type: Core
+date: 2023-09-25
 ---
 
 ## Table of contents

--- a/PIPs/PIP-12.md
+++ b/PIPs/PIP-12.md
@@ -1,9 +1,15 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 12 | Time Based StateSync Confirmations Delay  | Fix to the statesync confirmations issue in bor | [Jerry Chen](https://github.com/cffls), [Pratik Patil](https://github.com/pratikspatil024), [Manav Darji](https://github.com/manav2401) | [Forum](https://forum.polygon.technology/t/pip-12-time-based-statesync-confirmations-delay/11950)  | Final | Core | 2023-05-11
+---
+pip: 12
+title: Time Based StateSync Confirmations Delay
+description: Fix to the statesync confirmations issue in bor
+author: Jerry Chen (@cffls), Pratik Patil (@pratikspatil024), Manav Darji (@manav2401)
+discussion: https://forum.polygon.technology/t/pip-12-time-based-statesync-confirmations-delay/11950
+status: Final
+type: Core
+date: 2023-05-11
 ---
 
-### Abstract 
+### Abstract
 
 [PIP-10](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-10.md) outlined a state sync bug that can arise when network partitions (reorg) have lengths  > `sprintLength` (16 blocks). In summary, the issue occurs when the two chains eventually merge, as the current value of  `to` (which is used to fetch the state sync events) is based on `sprintLength`. Block production will occur at different times on each fork, meaning nodes on the incoming chain may have a different number of state sync transactions.
 

--- a/PIPs/PIP-13.md
+++ b/PIPs/PIP-13.md
@@ -1,6 +1,12 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 13 | Indore Hard Fork  | Proposes the Indore Hardfork | [Pratik Patil](https://github.com/pratikspatil024), [Sandeep Sreenath](https://github.com/ssandeep) | [Forum](https://forum.polygon.technology/t/indore-hard-fork/12272)  | Final | Core | 2023-06-27
+---
+pip: 13
+title: Indore Hard Fork
+description: Proposes the Indore Hardfork
+author: Pratik Patil (@pratikspatil024), Sandeep Sreenath (@ssandeep)
+discussion: https://forum.polygon.technology/t/indore-hard-fork/12272
+status: Final
+type: Core
+date: 2023-06-27
 ---
 
 ### Abstract 

--- a/PIPs/PIP-14.md
+++ b/PIPs/PIP-14.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 14 | Checkpoint Buffer Time  | Increase in Checkpoint Buffer Time | [Vaibhav Jindal](https://github.com/VAIBHAVJINDAL3012), [Sandeep Sreenath](https://github.com/ssandeep) | [Forum](https://forum.polygon.technology/t/pip-14-increase-checkpoint-buffer-time/12369)  | Final | Core | 2023-07-13
+---
+pip: 14
+title: Checkpoint Buffer Time
+description: Increase in Checkpoint Buffer Time
+author: Vaibhav Jindal (@VAIBHAVJINDAL3012), Sandeep Sreenath (@ssandeep)
+discussion: https://forum.polygon.technology/t/pip-14-increase-checkpoint-buffer-time/12369
+status: Final
+type: Core
+date: 2023-07-13
+---
 
 ### Abstract
 This proposal describes a change to the value of the ‘Checkpoint Buffer Time’ in Heimdall, from 1000 seconds to 1500 seconds.

--- a/PIPs/PIP-15.md
+++ b/PIPs/PIP-15.md
@@ -1,6 +1,12 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 15 | Adding support for EIP-4337 Bundled Transactions  | Proposes and Implements an additional API to support Bundled Transactions | [Pratik Patil](https://github.com/pratikspatil024) | [Forum](https://forum.polygon.technology/t/pip-adding-support-for-eip-4337-bundled-transactions/12679)  | Final | Interface | 2023-08-2
+---
+pip: 15
+title: Adding support for EIP-4337 Bundled Transactions
+description: Proposes and Implements an additional API to support Bundled Transactions
+author: Pratik Patil (@pratikspatil024)
+discussion: https://forum.polygon.technology/t/pip-adding-support-for-eip-4337-bundled-transactions/12679
+status: Final
+type: Interface
+date: 2023-08-02
 ---
 
 ### Abstract 

--- a/PIPs/PIP-16.md
+++ b/PIPs/PIP-16.md
@@ -1,7 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 16 | Transaction Dependency Data | Improving the efficiency of block validation by adding transaction dependency data to block header | [Jerry Chen](https://github.com/cffls), [Pratik Patil](https://github.com/pratikspatil024) | [Forum](https://forum.polygon.technology/t/proposal-transaction-dependency-data/12705)  | Draft  | Core | 2023-08-04 |
-
+---
+pip: 16
+title: Transaction Dependency Data
+description: Improving the efficiency of block validation by adding transaction dependency data to block header
+author: Jerry Chen (@cffls), Pratik Patil (@pratikspatil024)
+discussion: https://forum.polygon.technology/t/proposal-transaction-dependency-data/12705
+status: Draft
+type: Core
+date: 2023-08-04
+---
 
 ## Abstract
 

--- a/PIPs/PIP-17.md
+++ b/PIPs/PIP-17.md
@@ -1,7 +1,14 @@
-| PIP| Title| Description| Author| Discussion | Status | Type | Date|
-|-|-|-|-|-|-|-|-|
-|17| Polygon Ecosystem Token (POL) | Upgrade to MATIC in the form of the Polygon Ecosystem Token (POL) |Mihailo Bjelic, Mudit Gupta, Will Schwab, Daniel Gretzke, Dhairya Sethi, Ankit Maity, Harry Rook, Mateusz Rzeszowski| [Forum](https://forum.polygon.technology/t/pip-17-polygon-ecosystem-token-pol/12912) | Peer Review | Contracts | 2023-09-14 |
- 
+---
+pip: 17
+title: Polygon Ecosystem Token (POL)
+description: Upgrade to MATIC in the form of the Polygon Ecosystem Token (POL)
+author: Mihailo Bjelic, Mudit Gupta, Will Schwab, Daniel Gretzke, Dhairya Sethi, Ankit Maity, Harry Rook (@hrook1), Mateusz Rzeszowski
+discussion: https://forum.polygon.technology/t/pip-17-polygon-ecosystem-token-pol/12912
+status: Peer Review
+type: Contracts
+date: 2023-09-14
+---
+
 ### Abstract
 
 This proposal describes an upgrade to MATIC (0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0) in the form of the Polygon Ecosystem Token (POL). POL is the upgraded native token of Polygon 2.0, along with its accompanying contracts and initial configurations to handle emission management and token migration. POL allows for a one-to-one migration with MATIC with an initial supply of 10 billion POL and yearly emission of 2% that will be equally distributed to stakers and a community treasury contract.

--- a/PIPs/PIP-18.md
+++ b/PIPs/PIP-18.md
@@ -1,7 +1,13 @@
-| PIP| Title| Description| Author| Discussion | Status | Type | Date|
-|-|-|-|-|-|-|-|-|
-| 18 | Polygon 2.0 Phase 0 - Frontier| Specification of Polygon 2.0 - Phase 0 |David Schwartz, Mihailo Bjelic, Mudit Gupta, Grace Torrellas, Mateusz Rzeszowski, Daniel Gretzke, David Silverman, Paul Gebheim| [Forum](https://forum.polygon.technology/t/pip-18-polygon-2-0-phase-0-frontier/12913)| Draft | Informational | 2023-09-14 |
-
+---
+pip: 18
+title: Polygon 2.0 Phase 0 - Frontier
+description: Specification of Polygon 2.0 - Phase 0
+author: David Schwartz, Mihailo Bjelic, Mudit Gupta, Grace Torrellas, Mateusz Rzeszowski (@matrzeszowski), Daniel Gretzke, David Silverman, Paul Gebheim
+discussion: https://forum.polygon.technology/t/pip-18-polygon-2-0-phase-0-frontier/12913
+status: Draft
+type: Informational
+date: 2023-09-14
+---
 
 ### Abstract
 

--- a/PIPs/PIP-19.md
+++ b/PIPs/PIP-19.md
@@ -1,8 +1,13 @@
-| PIP| Title| Description| Author| Discussion | Status | Type | Date|
-|-|-|-|-|-|-|-|-|
-| 19 | Update Polygon PoS Native Token to POL| Upgrades the native token of the Polygon PoS network from MATIC to POL |Will Schwab, Daniel Gretzke, Dhairya Sethi, Zero Ekkusu| [Forum](https://forum.polygon.technology/t/pip-19-update-polygon-pos-native-token-to-pol/12914)| Peer Review | Contracts | 2023-09-14 |**
-
-    
+---
+pip: 19
+title: Update Polygon PoS Native Token to POL
+description: Upgrades the native token of the Polygon PoS network from MATIC to POL
+author: Will Schwab (@wschwab), Daniel Gretzke, Dhairya Sethi, Zero Ekkusu
+discussion: https://forum.polygon.technology/t/pip-19-update-polygon-pos-native-token-to-pol/12914
+status: Peer Review
+type: Contracts
+date: 2023-09-14
+---
 
 ### Abstract
 

--- a/PIPs/PIP-20.md
+++ b/PIPs/PIP-20.md
@@ -1,8 +1,13 @@
-
-
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 20 | State-Sync Verbosity | Proposal to introduce more visibility of state-sync transactions | [Shivam Sharma](https://github.com/0xsharma), [Sandeep Sreenath](https://github.com/ssandeep), [William Schwab](https://github.com/wschwab) | [Forum](https://forum.polygon.technology/t/pip-20-state-sync-verbosity/13050) | Peer Review | Core | 2023-09-14 |
+---
+pip: 20
+title: State-Sync Verbosity
+description: Proposal to introduce more visibility of state-sync transactions
+author: Shivam Sharma (@0xsharma), Sandeep Sreenath (@ssandeep), William Schwab (@wschwab)
+discussion: https://forum.polygon.technology/t/pip-20-state-sync-verbosity/13050
+status: Peer Review
+type: Core
+date: 2023-09-14
+---
 
 ## Abstract
 

--- a/PIPs/PIP-21.md
+++ b/PIPs/PIP-21.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 21 | Aalborg Hard Fork | Specifies the changes included in the Polygon hard fork named Aalborg | [Sandeep Sreenath](https://github.com/ssandeep)  | Draft  | Last Call | Core |2023-09-21
+---
+pip: 21
+title: Aalborg Hard Fork
+description: Specifies the changes included in the Polygon hard fork named Aalborg
+author: Sandeep Sreenath (@ssandeep)
+discussion: Draft
+status: Last Call
+type: Core
+date: 2023-09-21
+---
 
 ### Abstract
 

--- a/PIPs/PIP-22.md
+++ b/PIPs/PIP-22.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 22 | EIP-3074-style Account Abstraction | Implementation of the `AUTH` and `AUTHCALL` EVM opcodes  | Will Schwab (@wschwab) | [Forum](https://forum.polygon.technology/t/pip-add-eip-3074-style-account-abstraction/12959/1)  | Draft  | Core | 2023-09-22 |
+---
+pip: 22
+title: EIP-3074-style Account Abstraction
+description: Implementation of the `AUTH` and `AUTHCALL` EVM opcodes
+author: Will Schwab (@wschwab)
+discussion: https://forum.polygon.technology/t/pip-add-eip-3074-style-account-abstraction/12959/1
+status: Draft
+type: Core
+date: 2023-09-22
+---
 
 ## Abstract
 

--- a/PIPs/PIP-23.md
+++ b/PIPs/PIP-23.md
@@ -1,8 +1,13 @@
-
-
-| PIP | Title                         | Description                                     | Author                                                                                                | Discussion | Status      | Type                                     | Date       |
-|-----|-------------------------------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------|------------|-------------|------------------------------------------|------------|
-| 23  | Shanghai | Proposal to activate Ethereum Shanghai features | [Marcello Ardizzone](https://github.com/marcello33), [Sandeep Sreenath](https://github.com/ssandeep)  | [Forum](https://forum.polygon.technology/t/pip-23-proposal-to-activate-ethereum-shanghai-features/13065)  | Peer Review | Core | 2023-09-22 |
+---
+pip: 23
+title: Shanghai
+description: Proposal to activate Ethereum Shanghai features
+author: Marcello Ardizzone (@marcello33), Sandeep Sreenath (@ssandeep)
+discussion: https://forum.polygon.technology/t/pip-23-proposal-to-activate-ethereum-shanghai-features/13065
+status: Peer Review
+type: Core
+date: 2023-09-22
+---
 
 ## Abstract
 

--- a/PIPs/PIP-24.md
+++ b/PIPs/PIP-24.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |  
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|  
-| 24 | Change EIP-1559 Policy | Changes the EIP-1559 implementation to facilitate changes as introduced in PIP-18 | David Silverman, Paul Gebheim, Harry Rook, Mateusz Rzeszowski  | [Forum](https://forum.polygon.technology/t/pip-24-change-eip-1559-policy/13007)  | Draft | Core |2023-10-04
+---
+pip: 24
+title: Change EIP-1559 Policy
+description: Changes the EIP-1559 implementation to facilitate changes as introduced in PIP-18
+author: David Silverman, Paul Gebheim, Harry Rook, Mateusz Rzeszowski (@matrzeszowski)
+discussion: https://forum.polygon.technology/t/pip-24-change-eip-1559-policy/13007
+status: Draft
+type: Core
+date: 2023-10-04
+---
 
 ### Abstract
 

--- a/PIPs/PIP-25.md
+++ b/PIPs/PIP-25.md
@@ -1,7 +1,14 @@
-| PIP              | Title                          | Description         | Author                       | Discussion | Status | Type                                    | Date                 |  
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|  
-| 25 | Adjust POL Total Supply | Proposes burning POL tokens corresponding to previously burned MATIC | David Silverman, Paul Gebheim, Harry Rook, Mateusz Rzeszowski | [Forum](https://forum.polygon.technology/t/pip-25-adjust-pol-total-supply/13008) |  Draft | Contracts |2023-10-04
- 
+---
+pip: 25
+title: Adjust POL Total Supply
+description: Proposes burning POL tokens corresponding to previously burned MATIC
+author: David Silverman, Paul Gebheim, Harry Rook, Mateusz Rzeszowski (@matrzeszowski)
+discussion: https://forum.polygon.technology/t/pip-25-adjust-pol-total-supply/13008
+status: Draft
+type: Contracts
+date: 2023-10-04
+---
+
 ### Abstract
 
 In response to community feedback, this PIP proposes that the `burn()` function be called on the migrator contract, introduced in [PIP-17](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-17.md), in order to burn an amount of POL equivalent to MATIC in the addresses currently used to permanently remove MATIC tokens from supply (ex: 0x000..dEaD) as well as other permanently inaccessible tokens, thus bringing the POL circulating supply inline with the MATIC supply.

--- a/PIPs/PIP-26.md
+++ b/PIPs/PIP-26.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 26 | Transition from MATIC to POL Validator Rewards | Proposes aligning the initial POL Validator Rewards to current rewards schedule | [Derek Meyer](https://twitter.com/data_nexus) [Dimitri Nikolaros](https://twitter.com/dnikolaros)  | [Forum Post](https://forum.polygon.technology/t/pip-26-transition-from-matic-to-pol-validator-rewards/13046) | Draft  | Contracts | 2023-10-12
+---
+pip: 26
+title: Transition from MATIC to POL Validator Rewards
+description: Proposes aligning the initial POL Validator Rewards to current rewards schedule
+author: Derek Meyer (@Data-Nexus), Dimitri Nikolaros
+discussion: https://forum.polygon.technology/t/pip-26-transition-from-matic-to-pol-validator-rewards/13046
+status: Draft
+type: Contracts
+date: 2023-10-12
+---
 
 ### Abstract
 
@@ -40,5 +47,3 @@ This change causes no identifiable backward incompatibilities.
 ### Copyright
 
 All copyrights and related rights in this work are waived under CC0 1.0 Universal.
-
-

--- a/PIPs/PIP-27.md
+++ b/PIPs/PIP-27.md
@@ -1,6 +1,13 @@
-| PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
-|-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 27 | Precompiled for secp256r1 Curve Support | Proposal to add precompiled contract that performs signature verifications in the “secp256r1” elliptic curve. | Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan) | [Forum](https://forum.polygon.technology/t/new-pip-precompiled-for-secp256r1-curve-support/13049?u=ulerdogan) | Draft  | Core | 2023-10-12 |
+---
+pip: 27
+title: Precompiled for secp256r1 Curve Support
+description: Proposal to add precompiled contract that performs signature verifications in the “secp256r1” elliptic curve.
+author: Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan)
+discussion: https://forum.polygon.technology/t/new-pip-precompiled-for-secp256r1-curve-support/13049?u=ulerdogan
+status: Draft
+type: Core
+date: 2023-10-12
+---
 
 ## Abstract
 

--- a/PIPs/PIP-28.md
+++ b/PIPs/PIP-28.md
@@ -1,9 +1,15 @@
-| PIP | Title          | Description                | Author                        | Discussion | Status | Type                                     | Date                  |
-|-----|----------------|----------------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 28  | Agra Hard Fork | Proposes the Agra Hardfork | [Marcello Ardizzone](https://github.com/marcello33), [Sandeep Sreenath](https://github.com/ssandeep) | [Forum](https://forum.polygon.technology/t/pip-28-agra-hardfork/13067)  | Draft  | Core | 2023-10-17
+---
+pip: 28
+title: Agra Hard Fork
+description: Proposes the Agra Hardfork
+author: Marcello Ardizzone (@marcello33), Sandeep Sreenath (@ssandeep)
+discussion: https://forum.polygon.technology/t/pip-28-agra-hardfork/13067
+status: Draft
+type: Core
+date: 2023-10-17
 ---
 
-### Abstract 
+### Abstract
 
 This PIP specifies the changes included in the Polygon hard fork named Agra.
 


### PR DESCRIPTION
# Description

This pull request creates a GitHub Actions workflow that runs [`eipw`](https://github.com/ethereum/eipw), and updates PIPs into a format it understands.

## Fixes #117