### PR TITLE
Update PIP-27: Move to Final

### DIFF
--- a/PIPs/PIP-27.md
+++ b/PIPs/PIP-27.md
@@ -1,6 +1,6 @@
 | PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
 |-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 27 | Precompiled for secp256r1 Curve Support | Proposal to add precompiled contract that performs signature verifications in the “secp256r1” elliptic curve. | Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan) | [Forum](https://forum.polygon.technology/t/new-pip-precompiled-for-secp256r1-curve-support/13049?u=ulerdogan) | Last Call  | Core | 2023-10-12 |
+| 27 | Precompiled for secp256r1 Curve Support | Proposal to add precompiled contract that performs signature verifications in the “secp256r1” elliptic curve. | Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan) | [Forum](https://forum.polygon.technology/t/new-pip-precompiled-for-secp256r1-curve-support/13049?u=ulerdogan) | Final  | Core | 2023-10-12 |
 
 ## Abstract
 


### PR DESCRIPTION
# Description

Moves PIP-27 to the Final status following RIP-7212.


## Type of change

Please delete options that are not relevant.

- [ ]  New PIP
- [ ]  Revision to an existing PIP
- [ ]  This change requires a documentation update
- [ ]  My edit follows the style guidelines
