### PR TITLE
PIP 20 : Status changed to 'Final'

### DIFF
--- a/PIPs/PIP-20.md
+++ b/PIPs/PIP-20.md
@@ -2,7 +2,7 @@
 
 | PIP               | Title                           | Description          | Author                        | Discussion | Status | Type                                     | Date                  |
 |-------------------|---------------------------------|----------------------|-------------------------------|------------|--------|------------------------------------------|-----------------------|
-| 20 | State-Sync Verbosity | Proposal to introduce more visibility of state-sync transactions | [Shivam Sharma](https://github.com/0xsharma), [Sandeep Sreenath](https://github.com/ssandeep), [William Schwab](https://github.com/wschwab) | [Forum](https://forum.polygon.technology/t/pip-20-state-sync-verbosity/13050) | Last call | Core | 2023-09-14 |
+| 20 | State-Sync Verbosity | Proposal to introduce more visibility of state-sync transactions | [Shivam Sharma](https://github.com/0xsharma), [Sandeep Sreenath](https://github.com/ssandeep), [William Schwab](https://github.com/wschwab) | [Forum](https://forum.polygon.technology/t/pip-20-state-sync-verbosity/13050) | Final | Core | 2023-09-14 |
 
 ## Abstract
 


### PR DESCRIPTION
# Description

Changed the PIP-20 status from `Last Call` to `Final`. 

## Type of change

Please delete options that are not relevant.

- [ ]  New PIP
- [x]  Revision to an existing PIP
- [ ]  This change requires a documentation update
- [x]  My edit follows the style guidelines
