### PR TITLE
PIP36: Update tree depth, & function signatures

### DIFF
--- a/PIPs/PIP-36.md
+++ b/PIPs/PIP-36.md
@@ -86,7 +86,7 @@ We propose the StateReceiver also stores the failed state syncs.
 
 mapping failedStateSyncs (uint stateId ⇒ bytes encodedData (abi.encode(receiver, data)).
 
-which can be re-executed once by anyone through an external method `retryStateSync(uint stateId)`
+which can be re-executed once by anyone through an external method `replayFailedStateSync(uint stateId)`
 
 This would delete the entry in failedStateSyncs mapping only on a successful call.
 
@@ -103,9 +103,9 @@ The State Receiver currently emits `StateCommitted(uint stateId, bool success)`.
 
 A merkle tree of previous failed state syncs from the Shanghai Hardfork (50563600) until the present (an ever-expanding list) is created.
 
-A package to fetch and filter historic events will be made public such that this tree can be built, and root cross-checked by anyone. This will be a very small merkle tree of depth 5, where the leaf’s will be the keccak(abi.encode(stateId, receiver, calldata)) \[stateId provides sufficient collision resistance].
+A package to fetch and filter historic events will be made public such that this tree can be built, and root cross-checked by anyone. This will be a merkle tree of depth 16, where the leaf’s will be the keccak(abi.encode(stateId, receiver, calldata)) \[stateId provides sufficient collision resistance].
 
-An external method on StateReceiver will be exposed: `retryStateSync(uint stateId, bytes calldata stateSyncData, bytes32[5] calldata merkeProof)` which nullifies the leaf on successful state syncs.
+An external method on StateReceiver will be exposed: `replayHistoricFailedStateSync(bytes32[16] calldata proof, uint256 leafIndex, uint256 stateId, address receiver, bytes calldata data)` which nullifies the leaf on successful state syncs.
 
 ### Observability
 


### PR DESCRIPTION
# Description

- Update Tree Depth to 16 instead of 5.
- Update `retryStateSync` method name to `replayFailedStateSync`, & `retryStateSync` method signature.

## Type of change

- [x]  Revision to an existing PIP
- [x]  This change requires a documentation update
- [x]  My edit follows the style guidelines
