### PR TITLE
docs(pip-42): update backward compatibility

### DIFF
--- a/PIPs/PIP-42.md
+++ b/PIPs/PIP-42.md
@@ -42,7 +42,7 @@ function buyVoucherPOL(uint256 _amount, uint256 _minSharesToMint) public returns
 
 ## Backward Compatibility
 
-Backward compatibility has been preserved by internally converting MATIC to POL in the existing functions.
+Backward compatibility has been preserved by internally converting MATIC to POL (and vice-versa) in the existing functions.
 
 ## Security Considerations
 

--- a/PIPs/PIP-42.md
+++ b/PIPs/PIP-42.md
@@ -42,7 +42,7 @@ function buyVoucherPOL(uint256 _amount, uint256 _minSharesToMint) public returns
 
 ## Backward Compatibility
 
-Systems that expect to stake and unstake MATIC from the PoS Staking system will be affected unless they move to using the new legacy functions.
+Backward compatibility has been preserved by internally converting MATIC to POL in the existing functions.
 
 ## Security Considerations
 


### PR DESCRIPTION
# Description

Update PIP-42.

## Fixes

The section "Backward Compatibility" is outdated.

## Type of change

- [ ]  New PIP
- [x]  Revision to an existing PIP
- [x]  This change requires a documentation update
- [x]  My edit follows the style guidelines
