### PR TITLE
add pip-53 for jorvik HF

### DIFF
--- a/PIPs/PIP-53.md
+++ b/PIPs/PIP-53.md
@@ -1,0 +1,31 @@
+---
+PIP: 53
+Title: Jorvik Hardfork
+Description: Proposes the Jorvik Hardfork 
+Author: Marcello Ardizzone (@marcello33), Raneet Debnath (@Raneet10), Angel Valkov (@avalkov) 
+Discussion: TODO
+Status: Draft
+Type: Core
+Date: 2024-12-3
+---
+### Abstract
+
+This PIP specifies the changes included in the Polygon PoS hard fork named Jorvik.
+
+### Specification
+
+- Codename: Jorvik
+
+### Activation
+
+- Activation block:
+  * For Amoy - `5768528`
+  * For Mainnet - TBD
+
+### Included PIPs
+
+  *   [PIP-52: Execution Derived Randomness for Producer Selection](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-52.md)
+
+### Copyright
+
+All copyrights and related rights in this work are waived under CC0 1.0 Universal.


### PR DESCRIPTION
# Description

This PR adds PIP-53 for the Jorvik HF for PoS. 

## Type of change

Please delete options that are not relevant.

- [x]  New PIP
- [x]  My edit follows the style guidelines
