### PR TITLE
Add forum links to pip-55 and 56 and amend links

### DIFF
--- a/PIPs/PIP-55.md
+++ b/PIPs/PIP-55.md
@@ -3,7 +3,7 @@ PIP: 55
 Title: Addition of a new span message type in heimdall
 Author: Raneet Debnath (@Raneet10), Angel Valkov (@avalkov)
 Description: Proposes a new span message transaction type in heimdall
-Discussion: TODO
+Discussion: https://forum.polygon.technology/t/pip-55-new-span-message-type-in-heimdall/20510
 Status: Draft
 Type: Core
 Date: 2025-01-08
@@ -41,7 +41,7 @@ SeedAuthor common.Address          `json:"seed_author"`
 where `SeedAuthor` is the producer of the bor block whose hash corresponds to `Seed`.
 
 ## Specification
-For context, refer to [PIP-52](https://github.com/Raneet10/Polygon-Improvement-Proposals/blob/raneet10/pip-55/PIPs/PIP-52.md) and [PIP-53](https://github.com/Raneet10/Polygon-Improvement-Proposals/blob/raneet10/pip-55/PIPs/PIP-53.md).
+For context, refer to [PIP-52](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-52.md) and [PIP-53](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-53.md).
 After the Jorvik hardfork went live on Amoy, we saw several instances of heimdall nodes crashing. Upon investigation, it was revealed this happened due to a non-deterministic change introduced when a span is being committed in the database:
 
 ```go

--- a/PIPs/PIP-56.md
+++ b/PIPs/PIP-56.md
@@ -3,7 +3,7 @@ PIP: 56
 Title: Danelaw Hardfork
 Description: Proposes the Danelaw Hardfork 
 Author: Harry Rook (@hrook1) Raneet Debnath (@Raneet10)
-Discussion: 
+Discussion: https://forum.polygon.technology/t/pip-56-danelaw-hardfork/20511
 Status: Draft
 Type: Core
 Date: 2025-01-15


### PR DESCRIPTION
# Description

This PR adds forum post links for PIP-55 and 56 and updates links for PIP-52 and PIP-53 to point to the main repo. 

## Type of change

Please delete options that are not relevant.

- [ ]  New PIP
- [x]  Revision to an existing PIP
- [ ]  This change requires a documentation update
- [ ]  My edit follows the style guidelines
