### PR TITLE
Add PIP-88 for CHECKPOINT_REWARD recalibration

### DIFF
--- a/PIPs/PIP-88.md
+++ b/PIPs/PIP-88.md
@@ -16,7 +16,7 @@ Date: 2026-04-29
   and updated through `updateCheckpointReward(uint256)`, must therefore be reduced proportionally.  
   This PIP proposes two new values, each to be applied at the moment its corresponding
   block-time change goes live:  
-  **29,414.81 POL** when block time becomes 1.75s, and **25,212.92 POL** when block time becomes 1.5s.
+  **29,414.92 POL** when block time becomes 1.75s, and **25,212.79 POL** when block time becomes 1.5s.
 
   ## Motivation
 
@@ -37,10 +37,10 @@ Date: 2026-04-29
   `StakeManager.updateCheckpointReward(uint256 newReward)` (`onlyGovernance`) is invoked through the `Governance` contract twice, each call timed to coincide with the corresponding block-time change on Polygon PoS:
 
   1. **At block-time transition to 1.75s (planned for 2026-05-05):**
-     - `newReward` = `29414916286149162861491` (29,414.81 POL, 18 decimals)
+     - `newReward` = `29414916286149162861491` (29,414.92 POL, 18 decimals)
 
   2. **At block-time transition to 1.5s (planned for 2026-05-19):**
-     - `newReward` = `25212785388127853881278` (25,212.92 POL, 18 decimals)
+     - `newReward` = `25212785388127853881278` (25,212.79 POL, 18 decimals)
 
   Both transactions target the L1 `StakeManager` proxy at `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`. Each successful execution emits `RewardUpdate(newReward, oldReward)` on the `StakingInfo` logger at
   `0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B`.

--- a/PIPs/PIP-88.md
+++ b/PIPs/PIP-88.md
@@ -2,7 +2,7 @@
 PIP: 88
 Title: Recalibrate CHECKPOINT_REWARD for reduced Polygon block times
 Author: Simon Dosch (@simonDos)
-Description: Scale down `CHECKPOINT_REWARD` in lockstep with the planned ~2s → 1.5s → 1s block-time reductions to hold annual POL emission constant.
+Description: Scale down `CHECKPOINT_REWARD` in lockstep with the planned ~2s → 1.75s → 1.5s block-time reductions to hold annual POL emission constant.
 Discussion: TBA
 Status: Draft
 Type: Core
@@ -11,12 +11,12 @@ Date: 2026-04-29
 
   ## Abstract
 
-  Polygon PoS is reducing its average block time in two steps, from approximately 2.1s to 1.5s, and subsequently to 1.0s. Because checkpoints are submitted every `checkPointBlockInterval = 5120` blocks, a shorter
+  Polygon PoS is reducing its average block time in two steps, from approximately 2s to 1.75s, and subsequently to 1.5s. Because checkpoints are submitted every `checkPointBlockInterval = 5120` blocks, a shorter
   block time directly increases the number of checkpoints submitted per year. The per-checkpoint emission parameter `CHECKPOINT_REWARD`, set on the L1 `StakeManager` (`0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`)
   and updated through `updateCheckpointReward(uint256)`, must therefore be reduced proportionally.  
   This PIP proposes two new values, each to be applied at the moment its corresponding
   block-time change goes live:  
-  **24,782.84 POL** when block time becomes 1.5s, and **16,521.89 POL** when block time becomes 1.0s.
+  **28,913.32 POL** when block time becomes 1.75s, and **24,782.84 POL** when block time becomes 1.5s.
 
   ## Motivation
 
@@ -27,8 +27,8 @@ Date: 2026-04-29
   checkpoints_per_year = seconds_per_year / (block_time × checkPointBlockInterval)
   ```
 
-  If block time is reduced without adjusting `CHECKPOINT_REWARD`, the validator reward budget increases mechanically. At a 1.0s block time, leaving the
-  parameter unchanged would increase emission by roughly 2× over the current target.
+  If block time is reduced without adjusting `CHECKPOINT_REWARD`, the validator reward budget increases mechanically. At a 1.5s block time, leaving the
+  parameter unchanged would increase emission by roughly 1.4× over the current target.
 
   The intent of this PIP is therefore narrow and mechanical: hold annualized emission constant in POL terms while the block-time change ships.
 
@@ -36,11 +36,11 @@ Date: 2026-04-29
 
   `StakeManager.updateCheckpointReward(uint256 newReward)` (`onlyGovernance`) is invoked through the `Governance` contract twice, each call timed to coincide with the corresponding block-time change on Polygon PoS:
 
-  1. **At block-time transition to 1.5s:**
-     - `newReward` = `24782840000000000000000` (24,782.84 POL, 18 decimals)
+  1. **At block-time transition to 1.75s (planned for 2026-05-05):**
+     - `newReward` = `28913320000000000000000` (28,913.32 POL, 18 decimals)
 
-  2. **At block-time transition to 1.0s:**
-     - `newReward` = `16521890000000000000000` (16,521.89 POL, 18 decimals)
+  2. **At block-time transition to 1.5s (planned for 2026-05-19):**
+     - `newReward` = `24782840000000000000000` (24,782.84 POL, 18 decimals)
 
   Both transactions target the L1 `StakeManager` proxy at `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`. Each successful execution emits `RewardUpdate(newReward, oldReward)` on the `StakingInfo` logger at
   `0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B`.
@@ -69,8 +69,8 @@ Date: 2026-04-29
   | Phase | Block time | Checkpoints / yr | `CHECKPOINT_REWARD` (POL) 
   |-------|-----------:|-----------------:|--------------------------:
   | Today | 2.1s       | 2,933.04         | 34,695.98                 
-  | Step 1 | **1.5s**  | 4,106.25         | **24,782.84**             
-  | Step 2 | **1.0s**  | 6,159.375        | **16,521.89**             
+  | Step 1 (2026-05-05) | **1.75s** | 3,519.64 | **28,913.32**       
+  | Step 2 (2026-05-19) | **1.5s**  | 4,106.25 | **24,782.84**       
 
 
   ## Backwards Compatibility

--- a/PIPs/PIP-88.md
+++ b/PIPs/PIP-88.md
@@ -37,10 +37,10 @@ Date: 2026-04-29
   `StakeManager.updateCheckpointReward(uint256 newReward)` (`onlyGovernance`) is invoked through the `Governance` contract twice, each call timed to coincide with the corresponding block-time change on Polygon PoS:
 
   1. **At block-time transition to 1.75s (planned for 2026-05-05):**
-     - `newReward` = `29414810000000000000000` (29,414.81 POL, 18 decimals)
+     - `newReward` = `29414916286149162861491` (29,414.81 POL, 18 decimals)
 
   2. **At block-time transition to 1.5s (planned for 2026-05-19):**
-     - `newReward` = `25212920000000000000000` (25,212.92 POL, 18 decimals)
+     - `newReward` = `25212785388127853881278` (25,212.92 POL, 18 decimals)
 
   Both transactions target the L1 `StakeManager` proxy at `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`. Each successful execution emits `RewardUpdate(newReward, oldReward)` on the `StakingInfo` logger at
   `0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B`.
@@ -64,8 +64,8 @@ Date: 2026-04-29
   | Phase | Block time | Checkpoints / yr | `CHECKPOINT_REWARD` (POL) |
   |-------|-----------:|-----------------:|--------------------------:|
   | Today (PIP-78) | ~2.064s (implied) | 2,983.85 | 34,695.98 |
-  | Step 1 (2026-05-05) | **1.75s** | 3,519.64 | **29,414.81** |
-  | Step 2 (2026-05-19) | **1.5s**  | 4,106.25 | **25,212.92** |
+  | Step 1 (2026-05-05) | **1.75s** | 3,519.64 | **29,414.92** |
+  | Step 2 (2026-05-19) | **1.5s**  | 4,106.25 | **25,212.79** |
 
   Each row holds annualized emission at 103,530,000 POL (≈1% of the ~10.353B POL supply implied by PIP-78's target). The "today" row reflects the block time implied by PIP-78's calibration (target POL/yr ÷ current reward ÷ 5,120 blocks = ~2.064s/block), not a separate measurement.
 

--- a/PIPs/PIP-88.md
+++ b/PIPs/PIP-88.md
@@ -1,0 +1,100 @@
+---
+PIP: 88
+Title: Recalibrate CHECKPOINT_REWARD for reduced Polygon block times
+Author: Simon Dosch (@simonDos)
+Description: Scale down `CHECKPOINT_REWARD` in lockstep with the planned ~2s → 1.5s → 1s block-time reductions to hold annual POL emission constant.
+Discussion: TBA
+Status: Draft
+Type: Core
+Date: 2026-04-29
+---
+
+  ## Abstract
+
+  Polygon PoS is reducing its average block time in two steps, from approximately 2.1s to 1.5s, and subsequently to 1.0s. Because checkpoints are submitted every `checkPointBlockInterval = 5120` blocks, a shorter
+  block time directly increases the number of checkpoints submitted per year. The per-checkpoint emission parameter `CHECKPOINT_REWARD`, set on the L1 `StakeManager` (`0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`)
+  and updated through `updateCheckpointReward(uint256)`, must therefore be reduced proportionally.  
+  This PIP proposes two new values, each to be applied at the moment its corresponding
+  block-time change goes live:  
+  **24,782.84 POL** when block time becomes 1.5s, and **16,521.89 POL** when block time becomes 1.0s.
+
+  ## Motivation
+
+  `CHECKPOINT_REWARD` defines the amount of POL distributed to validators per checkpoint. Annual emission is therefore a function of two variables: the per-checkpoint reward and the number of checkpoints produced
+  per year. The number of checkpoints per year is itself a function of average block time:
+
+  ```
+  checkpoints_per_year = seconds_per_year / (block_time × checkPointBlockInterval)
+  ```
+
+  If block time is reduced without adjusting `CHECKPOINT_REWARD`, the validator reward budget increases mechanically. At a 1.0s block time, leaving the
+  parameter unchanged would increase emission by roughly 2× over the current target.
+
+  The intent of this PIP is therefore narrow and mechanical: hold annualized emission constant in POL terms while the block-time change ships.
+
+  ## Specification
+
+  `StakeManager.updateCheckpointReward(uint256 newReward)` (`onlyGovernance`) is invoked through the `Governance` contract twice, each call timed to coincide with the corresponding block-time change on Polygon PoS:
+
+  1. **At block-time transition to 1.5s:**
+     - `newReward` = `24782840000000000000000` (24,782.84 POL, 18 decimals)
+
+  2. **At block-time transition to 1.0s:**
+     - `newReward` = `16521890000000000000000` (16,521.89 POL, 18 decimals)
+
+  Both transactions target the L1 `StakeManager` proxy at `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`. Each successful execution emits `RewardUpdate(newReward, oldReward)` on the `StakingInfo` logger at
+  `0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B`.
+
+  No contract upgrades are required. No other parameters (`checkPointBlockInterval`, `proposerBonus`, `dynasty`, etc.) are changed by this PIP.
+
+  ## Rationale
+
+  The current value of `CHECKPOINT_REWARD` is **34,695.98 POL** (set 2026-02-19, see `RewardUpdate` history). At the current ~2.1s average block time:
+
+  ```
+  seconds_per_year      = 365 × 24 × 3600 = 31,536,000
+  checkpoints_per_year  = 31,536,000 / (2.1 × 5,120) ≈ 2,933.04
+  annual_emission       = 34,695.98 × 2,933.04        ≈ 101,763,260 POL
+  emission_rate         = 101,763,260 / 10,264,044,460 ≈ 0.991% of POL supply
+  ```
+
+  To hold `annual_emission` constant across a block-time change we can use:
+
+  ```
+  new_reward = old_reward × (new_block_time / old_block_time)
+  ```
+
+  Applying this to the planned transitions (anchored on the current 2.1s baseline):
+
+  | Phase | Block time | Checkpoints / yr | `CHECKPOINT_REWARD` (POL) 
+  |-------|-----------:|-----------------:|--------------------------:
+  | Today | 2.1s       | 2,933.04         | 34,695.98                 
+  | Step 1 | **1.5s**  | 4,106.25         | **24,782.84**             
+  | Step 2 | **1.0s**  | 6,159.375        | **16,521.89**             
+
+
+  ## Backwards Compatibility
+
+  This PIP introduces no backwards-incompatible behavior.
+  
+  ## Test Cases
+
+  `updateCheckpointReward` and the surrounding reward-distribution path are covered by the existing test suite in `pos-contracts`:
+
+  - `test/units/staking/stakeManager/StakeManager.test.js` exercises governance-gated updates and the resulting reward-calculation behavior.
+  - `test/units/root/RootChain.test.js` exercises checkpoint submission and reward emission end-to-end.
+
+  ## Security Considerations
+
+  - **Authorization.** `updateCheckpointReward` is `onlyGovernance`. Execution requires the governance multisig and follows the existing parameter-change process; no new privileged surface is introduced.
+  - **Misconfiguration risk.** Setting `CHECKPOINT_REWARD` to an incorrect value (wrong magnitude, wrong decimals) would either over-emit POL or under-pay validators. Mitigations: (a) the values in this PIP are
+  stated in both human-readable POL and 18-decimal wei form, (b) the deployer script asserts the post-state matches the intended value, (c) the change is reversible by a subsequent governance call.
+  - **Timing / sequencing.** The parameter change should be applied at — or as close as operationally feasible to — the block at which Polygon's average block time actually crosses to the new target. A large lag in
+   either direction causes a transient deviation from the target emission rate (over-emission if the parameter lags a faster block time; under-emission if the parameter changes before the block-time reduction takes
+   effect).
+  - **Validator economics.** The proposed values hold annual POL emission constant in absolute POL terms. Per-checkpoint reward decreases, but validators submit proportionally more checkpoints per unit time, so
+  per-unit-time validator rewards are unchanged in expectation.
+
+  ## Copyright
+
+  Copyright and related rights waived via [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).

--- a/PIPs/PIP-88.md
+++ b/PIPs/PIP-88.md
@@ -2,7 +2,7 @@
 PIP: 88
 Title: Recalibrate CHECKPOINT_REWARD for reduced Polygon block times
 Author: Simon Dosch (@simonDos)
-Description: Scale down `CHECKPOINT_REWARD` in lockstep with the planned ~2s → 1.75s → 1.5s block-time reductions to hold annual POL emission constant.
+Description: Scale down `CHECKPOINT_REWARD` in lockstep with the planned 1.75s and 1.5s block-time reductions to hold annual POL emission at the 1% target reaffirmed in PIP-78.
 Discussion: TBA
 Status: Draft
 Type: Core
@@ -16,7 +16,7 @@ Date: 2026-04-29
   and updated through `updateCheckpointReward(uint256)`, must therefore be reduced proportionally.  
   This PIP proposes two new values, each to be applied at the moment its corresponding
   block-time change goes live:  
-  **28,913.32 POL** when block time becomes 1.75s, and **24,782.84 POL** when block time becomes 1.5s.
+  **29,414.81 POL** when block time becomes 1.75s, and **25,212.92 POL** when block time becomes 1.5s.
 
   ## Motivation
 
@@ -30,17 +30,17 @@ Date: 2026-04-29
   If block time is reduced without adjusting `CHECKPOINT_REWARD`, the validator reward budget increases mechanically. At a 1.5s block time, leaving the
   parameter unchanged would increase emission by roughly 1.4× over the current target.
 
-  The intent of this PIP is therefore narrow and mechanical: hold annualized emission constant in POL terms while the block-time change ships.
+  The intent of this PIP is therefore to hold annualized emission constant in POL terms while the block-time changes.
 
   ## Specification
 
   `StakeManager.updateCheckpointReward(uint256 newReward)` (`onlyGovernance`) is invoked through the `Governance` contract twice, each call timed to coincide with the corresponding block-time change on Polygon PoS:
 
   1. **At block-time transition to 1.75s (planned for 2026-05-05):**
-     - `newReward` = `28913320000000000000000` (28,913.32 POL, 18 decimals)
+     - `newReward` = `29414810000000000000000` (29,414.81 POL, 18 decimals)
 
   2. **At block-time transition to 1.5s (planned for 2026-05-19):**
-     - `newReward` = `24782840000000000000000` (24,782.84 POL, 18 decimals)
+     - `newReward` = `25212920000000000000000` (25,212.92 POL, 18 decimals)
 
   Both transactions target the L1 `StakeManager` proxy at `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`. Each successful execution emits `RewardUpdate(newReward, oldReward)` on the `StakingInfo` logger at
   `0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B`.
@@ -49,28 +49,25 @@ Date: 2026-04-29
 
   ## Rationale
 
-  The current value of `CHECKPOINT_REWARD` is **34,695.98 POL** (set 2026-02-19, see `RewardUpdate` history). At the current ~2.1s average block time:
+  The current value of `CHECKPOINT_REWARD` is **34,695.98 POL** (set 2026-02-19 by PIP-78, see `RewardUpdate` history). PIP-78 sized that value to deliver the **1% annual emission target** for Year 6 of PIP-26, i.e. **103,530,000 POL/yr**. This PIP preserves that same target across the upcoming block-time reductions.
+
+  Solving directly for the per-checkpoint reward that yields 103,530,000 POL/yr at a given block time:
 
   ```
   seconds_per_year      = 365 × 24 × 3600 = 31,536,000
-  checkpoints_per_year  = 31,536,000 / (2.1 × 5,120) ≈ 2,933.04
-  annual_emission       = 34,695.98 × 2,933.04        ≈ 101,763,260 POL
-  emission_rate         = 101,763,260 / 10,264,044,460 ≈ 0.991% of POL supply
+  checkpoints_per_year  = seconds_per_year / (block_time × 5,120)
+  new_reward            = 103,530,000 / checkpoints_per_year
   ```
 
-  To hold `annual_emission` constant across a block-time change we can use:
+  Applying this to the planned transitions:
 
-  ```
-  new_reward = old_reward × (new_block_time / old_block_time)
-  ```
+  | Phase | Block time | Checkpoints / yr | `CHECKPOINT_REWARD` (POL) |
+  |-------|-----------:|-----------------:|--------------------------:|
+  | Today (PIP-78) | ~2.064s (implied) | 2,983.85 | 34,695.98 |
+  | Step 1 (2026-05-05) | **1.75s** | 3,519.64 | **29,414.81** |
+  | Step 2 (2026-05-19) | **1.5s**  | 4,106.25 | **25,212.92** |
 
-  Applying this to the planned transitions (anchored on the current 2.1s baseline):
-
-  | Phase | Block time | Checkpoints / yr | `CHECKPOINT_REWARD` (POL) 
-  |-------|-----------:|-----------------:|--------------------------:
-  | Today | 2.1s       | 2,933.04         | 34,695.98                 
-  | Step 1 (2026-05-05) | **1.75s** | 3,519.64 | **28,913.32**       
-  | Step 2 (2026-05-19) | **1.5s**  | 4,106.25 | **24,782.84**       
+  Each row holds annualized emission at 103,530,000 POL (≈1% of the ~10.353B POL supply implied by PIP-78's target). The "today" row reflects the block time implied by PIP-78's calibration (target POL/yr ÷ current reward ÷ 5,120 blocks = ~2.064s/block), not a separate measurement.
 
 
   ## Backwards Compatibility


### PR DESCRIPTION

# Description

This PIP proposes recalibrating the CHECKPOINT_REWARD to maintain annual POL emission constant in light of reduced block times on Polygon. It outlines the new reward values to be applied during the transitions to 1.5s and 1.0s block times.


## Type of change

- New PIP

